### PR TITLE
Fix #94: Add selected line break count to gutter

### DIFF
--- a/src/main/java/org/fife/rtext/RemoteFileChooser.java
+++ b/src/main/java/org/fife/rtext/RemoteFileChooser.java
@@ -573,12 +573,21 @@ public class RemoteFileChooser extends EscapableDialog
 		}
 	}
 
-	public JButton createButton(ResourceBundle msg, String textKey, String mnemonicKey,
+	/**
+	 * Creates a button to use in this modal.
+	 *
+	 * @param msg The resource bundle.
+	 * @param textKey The key for the button label.
+	 * @param mnemonicKey The key for button mnemonic.
+	 * @param actionCommand The action command to fire.
+	 * @param actionListener The listener for events on this button.
+	 * @return The button.
+	 */
+	protected JButton createButton(ResourceBundle msg, String textKey, String mnemonicKey,
 								String actionCommand, ActionListener actionListener) {
 		JButton button = UIUtil.newButton(msg, textKey, mnemonicKey);
 		button.setActionCommand(actionCommand);
 		button.addActionListener(actionListener);
-
 		return button;
 	}
 

--- a/src/main/resources/org/fife/rtext/StatusBar.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=Line {0}, Col. {1}
 FileSaveSuccessful=File save successful.
 OpenedFile=Opened file {0}.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_ar.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_ar.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=\u0633\u0637\u0631 {0}, \u0639\u0645\u0648\u062f {1}
 FileSaveSuccessful=\u062a\u0645 \u062d\u0641\u0638 \u0627\u0644\u0645\u0644\u0641 \u0628\u0646\u062c\u0627\u062d.
 OpenedFile=\u062a\u0645 \u0641\u062a\u062d \u0627\u0644\u0645\u0644\u0641 {0}.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_de.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_de.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=Zeile {0}, Spalte {1}
 FileSaveSuccessful=Dateispeichern erfolgreich.
 OpenedFile=Datei {0} ge\u00f6ffnet.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_es.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_es.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=L\u00ednea {0}, Col. {1}
 FileSaveSuccessful=Archivo guardado correctamente.
 OpenedFile=Archivo abierto {0}.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_fr.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_fr.properties
@@ -5,4 +5,4 @@ RowColumnIndicator=Ligne {0}, Col. {1}
 
 FileSaveSuccessful=Fichier sauvegard\u00e9.
 OpenedFile=Fichier {0} ouvert.
-SelectionLength={0} chars
+SelectionLength={0} chars{0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_hu.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_hu.properties
@@ -6,3 +6,5 @@ RowColumnIndicator={0} sor, {1} oszlop
 FileSaveSuccessful=A f\u00e1jl sikeresen mentve lett.
 OpenedFile=A(z) {0} f\u00e1jl megnyitva.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_in.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_in.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=Baris {0}, Kol. {1}
 FileSaveSuccessful=Sukses menyimpan File.
 OpenedFile=File yang terbuka {0}.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_it.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_it.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=Riga {0}, Col. {1}
 FileSaveSuccessful=File salvato con successo.
 OpenedFile=Fila aperto {0}.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_ja.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_ja.properties
@@ -6,3 +6,5 @@ RowColumnIndicator={0}\u884c, {1}\u6841
 FileSaveSuccessful=\u4fdd\u5b58\u3057\u307e\u3057\u305f
 OpenedFile=\u958b\u3044\u3066\u3044\u308b\u30d5\u30a1\u30a4\u30eb {0}.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_ko.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_ko.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=\ud589 {0}, \uc5f4 {1}
 FileSaveSuccessful=\ud30c\uc77c \uc800\uc7a5 \uc131\uacf5
 OpenedFile={0} \ud30c\uc77c\uc744 \uc5f4\uc600\uc2b5\ub2c8\ub2e4.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_nl.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_nl.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=Lijn {0}, Kol. {1}
 FileSaveSuccessful=Bestand Opgeslagen.
 OpenedFile=Bestand {0} Geopend.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_pl.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_pl.properties
@@ -6,3 +6,5 @@ OverwriteModeIndicator=ZAST
 ReadOnlyIndicator=Tylko do odczytu
 RowColumnIndicator=Wiersz {0}, kol. {1}
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_pt_BR.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_pt_BR.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=Lin {0}, Col. {1}
 FileSaveSuccessful=Arquivo salvo com sucesso.
 OpenedFile=Arquivo {0} aberto.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_ru.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_ru.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=\u0421\u0442\u0440. {0}, \u0421\u0442\u043e\u043b\u0431. {1}
 FileSaveSuccessful=\u0424\u0430\u0439\u043b \u0443\u0441\u043f\u0435\u0448\u043d\u043e \u0441\u043e\u0445\u0440\u0430\u043d\u0435\u043d.
 OpenedFile=\u041e\u0442\u043a\u0440\u044b\u0442 \u0444\u0430\u0439\u043b {0}.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_tr.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_tr.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=Satir {0}, Sut. {1}
 FileSaveSuccessful=Dosya Basariyla Kaydedildi.
 OpenedFile=Acilan Dosya {0}.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_zh_CN.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_zh_CN.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=\u884c {0},\u5217 {1}
 FileSaveSuccessful=\u6587\u4ef6\u4fdd\u5b58\u6210\u529f
 OpenedFile=\u6253\u5f00\u6587\u4ef6{0}.
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks

--- a/src/main/resources/org/fife/rtext/StatusBar_zh_TW.properties
+++ b/src/main/resources/org/fife/rtext/StatusBar_zh_TW.properties
@@ -6,3 +6,5 @@ RowColumnIndicator=\u7b2c{0}\u884c, \u7b2c{1}\u5217
 FileSaveSuccessful=\u6a94\u6848\u5b58\u5132\u6210\u529f\u3002
 OpenedFile=\u5df2\u6253\u958b\u6a94\u6848 {0}\u3002
 SelectionLength={0} chars
+SelectionLengthWithLineBreakCount={0} chars, {1} line break
+SelectionLengthWithLineBreakCountPlural={0} chars, {1} line breaks


### PR DESCRIPTION
Similar to IntelliJ, If the selection contains line breaks, display the line break count.

<img width="155" alt="image" src="https://github.com/user-attachments/assets/6cc2f358-862a-4798-b0f8-14127f674c49" />
